### PR TITLE
fix package conflict with gnome-python2

### DIFF
--- a/gtksourceview/Makefile.am
+++ b/gtksourceview/Makefile.am
@@ -7,8 +7,8 @@ EXTRA_DIST = gtksourceview.defs gtksourceview.override
 defsdir = $(datadir)/pygtk/2.0/defs
 defs_DATA = gtksourceview.defs
 
-pkgpythondir = $(pyexecdir)/gtk-2.0
-pkgpyexecdir = $(pyexecdir)/gtk-2.0
+pkgpythondir = $(pyexecdir)/gtk-2.0/mate
+pkgpyexecdir = $(pyexecdir)/gtk-2.0/mate
 
 # gtksourceview module
 pkgpyexec_LTLIBRARIES = gtksourceview.la

--- a/gtop/Makefile.am
+++ b/gtop/Makefile.am
@@ -1,8 +1,8 @@
 
 INCLUDES = $(PYTHON_INCLUDES) $(GTOP_CFLAGS)
 
-pkgpythondir = $(pyexecdir)/gtk-2.0
-pkgpyexecdir = $(pyexecdir)/gtk-2.0
+pkgpythondir = $(pyexecdir)/gtk-2.0/mate
+pkgpyexecdir = $(pyexecdir)/gtk-2.0/mate
 
 # gtop module
 pkgpyexec_LTLIBRARIES = gtop.la

--- a/rsvg/Makefile.am
+++ b/rsvg/Makefile.am
@@ -4,8 +4,8 @@ INCLUDES = $(PYTHON_INCLUDES) $(RSVG_CFLAGS)
 
 EXTRA_DIST = rsvg.defs rsvg.override
 
-pkgpythondir = $(pyexecdir)/gtk-2.0
-pkgpyexecdir = $(pyexecdir)/gtk-2.0
+pkgpythondir = $(pyexecdir)/gtk-2.0/mate
+pkgpyexecdir = $(pyexecdir)/gtk-2.0/mate
 
 # rsvg module
 pkgpyexec_LTLIBRARIES = rsvg.la


### PR DESCRIPTION
Those are current gnome-python2 fiiles.

/usr/lib64/python2.7/site-packages/gtk-2.0/rsvg.so

/usr/lib64/python2.7/site-packages/gtk-2.0/gtop.so

/usr/lib64/python2.7/site-packages/gtk-2.0/gtksourceview.so 
